### PR TITLE
Update package.json to support latest core release

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,20 +30,19 @@
   "module": "index.js",
   "typings": "index.d.ts",
   "peerDependencies": {
-    "@ngx-translate/core": "^6.0.0-beta.1",
-    "@angular/core": ">=2.3.0 || >=4.0.0-beta.0",
-    "@angular/http": ">=2.3.0 || >=4.0.0-beta.0"
+    "@ngx-translate/core": "^6.0.0",
+    "@angular/http": ">=2.0.0 || >=4.0.0-beta.0"
   },
   "devDependencies": {
-    "@angular/common": "2.4.6",
-    "@angular/compiler": "2.4.6",
-    "@angular/compiler-cli": "2.4.6",
-    "@angular/core": "2.4.6",
-    "@angular/http": "2.4.6",
-    "@ngx-translate/core": "6.0.0-beta.1",
-    "@angular/platform-browser": "2.4.6",
-    "@angular/platform-browser-dynamic": "2.4.6",
-    "@angular/platform-server": "2.4.6",
+    "@angular/common": "2.4.7",
+    "@angular/compiler": "2.4.7",
+    "@angular/compiler-cli": "2.4.7",
+    "@angular/core": "2.4.7",
+    "@angular/http": "2.4.7",
+    "@ngx-translate/core": "6.0.0",
+    "@angular/platform-browser": "2.4.7",
+    "@angular/platform-browser-dynamic": "2.4.7",
+    "@angular/platform-server": "2.4.7",
     "@types/hammerjs": "2.0.34",
     "@types/jasmine": "2.5.41",
     "@types/node": "7.0.4",
@@ -66,15 +65,15 @@
     "loader-utils": "0.2.16",
     "reflect-metadata": "0.1.9",
     "rimraf": "2.5.4",
-    "rxjs": "5.0.1",
+    "rxjs": "5.1.1",
     "semantic-release": "6.3.5",
     "source-map-loader": "0.1.6",
     "ts-helpers": "1.1.2",
     "tslint": "4.4.2",
-    "tslint-loader": "3.3.0",
+    "tslint-loader": "3.4.2",
     "typescript": "2.0.10",
     "webpack": "2.2.1",
-    "zone.js": "0.7.6"
+    "zone.js": "0.7.7"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
Also removed peerDependency on `@angular/core` - since `@ngx-translate/core` defines this as a peerDependency, it's redundant here.