### PR TITLE
support for http headers

### DIFF
--- a/src/http-loader.ts
+++ b/src/http-loader.ts
@@ -1,9 +1,9 @@
-import {HttpClient} from "@angular/common/http";
+import {HttpClient,HttpHeaders} from "@angular/common/http";
 import {TranslateLoader} from "@ngx-translate/core";
 import "rxjs/add/operator/map";
 
 export class TranslateHttpLoader implements TranslateLoader {
-    constructor(private http: HttpClient, private prefix: string = "/assets/i18n/", private suffix: string = ".json") {}
+    constructor(private http: HttpClient, private headers?: HttpHeaders, private prefix: string = "/assets/i18n/", private suffix: string = ".json") {}
 
     /**
      * Gets the translations from the server
@@ -11,6 +11,12 @@ export class TranslateHttpLoader implements TranslateLoader {
      * @returns {any}
      */
     public getTranslation(lang: string): any {
-        return this.http.get(`${this.prefix}${lang}${this.suffix}`);
+        if (this.headers) {
+            return this.http.get(`${this.prefix}${lang}${this.suffix}`, {
+                headers: this.headers
+            });
+        } else {
+            return this.http.get(`${this.prefix}${lang}${this.suffix}`);
+        }
     }
 }


### PR DESCRIPTION
After this pull request we can use:

`TranslateHttpBasicAuthLoader(http, new HttpHeaders().set('Authorization', 'Basic ' + btoa(conf.username + ':' + conf.password)), environment.base_path + '/i18n/', '.json');`