### PR TITLE
Allow setting prefix and suffix dynamically

### DIFF
--- a/src/http-loader.ts
+++ b/src/http-loader.ts
@@ -3,7 +3,7 @@ import {TranslateLoader} from "@ngx-translate/core";
 import "rxjs/add/operator/map";
 
 export class TranslateHttpLoader implements TranslateLoader {
-    constructor(private http: HttpClient, private prefix: string = "/assets/i18n/", private suffix: string = ".json") {}
+    constructor(private http: HttpClient, public prefix: string = "/assets/i18n/", public suffix: string = ".json") {}
 
     /**
      * Gets the translations from the server


### PR DESCRIPTION
This allows developers to update the path where the translation files are loaded from. It might be possible that this path is some kind of configuration option within the application.

Use case:
The company I work for, builds SharePoint WebParts. These WebParts can have custom properties. We use a property to tell the WebPart where the REST service is located that serves it's JavaScript files and localization files.