### PR TITLE
Load translations with promise, to allow preloading

### DIFF
--- a/projects/ngx-translate/http-loader/src/lib/http-loader.ts
+++ b/projects/ngx-translate/http-loader/src/lib/http-loader.ts
@@ -9,6 +9,24 @@ export class TranslateHttpLoader implements TranslateLoader {
    * Gets the translations from the server
    */
   public getTranslation(lang: string): Observable<Object> {
-    return this.http.get(`${this.prefix}${lang}${this.suffix}`);
+  	if (this.loadedTranslations != null && this.loadedTranslations[lang] != null) {
+  		return Observable.of(this.loadedTranslations[lang]);
+  	}
+  	return Observable.fromPromise(this.preLoad(lang));
+  }
+
+  /**
+   * Gets the translations from the server as Promise
+   * @param lang
+   * @returns Promise<any>
+   */
+  public preLoad(lang: string): Promise<any> {
+  	return this.http.get(`${this.prefix}${lang}${this.suffix}`)
+  		.toPromise()
+  		.then(result => {
+  			this.loadedTranslations[lang] = result;
+  			return result;
+  		})
+  		.catch(() => null); 
   }
 }


### PR DESCRIPTION
With APP_INITIALIZER and Promise we can load translations before app is started. 

Usage example:

```ts
let translateHttpLoader: TranslateHttpLoader;

export function loadTranslations(http: HttpClient) {  
      return () => httpLoaderFactory(http).preLoad("en");
}

// AoT requires an exported function for factories
export function httpLoaderFactory(http: HttpClient) {
      if(translateHttpLoader == null) {
        translateHttpLoader = new TranslateHttpLoader(http);
      }
      return translateHttpLoader;
}

@NgModule({
   imports: [...,
      TranslateModule.forRoot({
        loader: {
          provide: TranslateLoader,
          useFactory: httpLoaderFactory,
          deps: [HttpClient]
        }
      })
   ],
   declarations: [...],
   providers: [
       ..,
      {provide: APP_INITIALIZER, useFactory: loadTranslations, deps: [HttpClient], multi: true},
     ...
   ],
  bootstrap: [AppComponent]
})

export class AppModule {}
```