### PR TITLE
Update `@angular/common` peer-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@ngx-translate/core": ">=6.0.0",
     "@angular/core": ">=4.3.0",
-    "@angular/common": ">=4.3.0"
+    "@angular/common": ">=4.3.0 || >=5.0.0"
   },
   "devDependencies": {
     "@angular/animations": "4.3.1",


### PR DESCRIPTION
Update `@angular/common` peer-dependency to accept 5.x versions

Fixes: #32 