### PR TITLE
relative path to assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ export class AppModule { }
 ```
 
 The `TranslateHttpLoader` also has two optional parameters:
-- prefix: string = "/assets/i18n/"
+- prefix: string = "./assets/i18n/"
 - suffix: string = ".json"
 
-By using those default parameters, it will load your translations files for the lang "en" from: `/assets/i18n/en.json`.
+By using those default parameters, it will load your translations files for the lang "en" from: `./assets/i18n/en.json`.
 
 You can change those in the `HttpLoaderFactory` method that we just defined. For example if you want to load the "en" translations from `/public/lang-files/en-lang.json` you would use:
 
@@ -82,7 +82,7 @@ import { Observable } from 'rxjs/Observable';
 
 export class WebpackTranslateLoader implements TranslateLoader {
   getTranslation(lang: string): Observable<any> {
-    return Observable.fromPromise(System.import(`../assets/i18n/${lang}.json`));
+    return Observable.fromPromise(System.import(`.../assets/i18n/${lang}.json`));
   }
 }
 ```

--- a/lib/src/http-loader.ts
+++ b/lib/src/http-loader.ts
@@ -2,7 +2,7 @@ import {HttpClient} from "@angular/common/http";
 import {TranslateLoader} from "@ngx-translate/core";
 
 export class TranslateHttpLoader implements TranslateLoader {
-  constructor(private http: HttpClient, public prefix: string = "/assets/i18n/", public suffix: string = ".json") {}
+  constructor(private http: HttpClient, public prefix: string = "./assets/i18n/", public suffix: string = ".json") {}
 
   /**
    * Gets the translations from the server

--- a/tests/http-loader.spec.ts
+++ b/tests/http-loader.spec.ts
@@ -46,7 +46,7 @@ describe('TranslateLoader', () => {
     });
 
     // mock response after the xhr request, otherwise it will be undefined
-    http.expectOne('/assets/i18n/en.json').flush({
+    http.expectOne('./assets/i18n/en.json').flush({
       "TEST": "This is a test",
       "TEST2": "This is another test"
     });
@@ -69,11 +69,11 @@ describe('TranslateLoader', () => {
         expect(translate.instant('TEST')).toEqual('This is a test 2');
       });
 
-      http.expectOne('/assets/i18n/en.json').flush({"TEST": "This is a test 2"});
+      http.expectOne('./assets/i18n/en.json').flush({"TEST": "This is a test 2"});
     });
 
     // mock response after the xhr request, otherwise it will be undefined
-    http.expectOne('/assets/i18n/en.json').flush({"TEST": "This is a test"});
+    http.expectOne('./assets/i18n/en.json').flush({"TEST": "This is a test"});
   });
 
   it('should be able to reset a lang', (done: Function) => {
@@ -101,6 +101,6 @@ describe('TranslateLoader', () => {
     });
 
     // mock response after the xhr request, otherwise it will be undefined
-    http.expectOne('/assets/i18n/en.json').flush({"TEST": "This is a test"});
+    http.expectOne('./assets/i18n/en.json').flush({"TEST": "This is a test"});
   });
 });


### PR DESCRIPTION
changed "/assets/i18n/" to "./assets/i18n/" because the andular app would only find the translations if installed on the root of the server.