### PR TITLE
Use relative path so that we properly apply --base-href.

### DIFF
--- a/projects/ngx-translate/http-loader/src/lib/http-loader.ts
+++ b/projects/ngx-translate/http-loader/src/lib/http-loader.ts
@@ -3,7 +3,7 @@ import {TranslateLoader} from "@ngx-translate/core";
 import {Observable} from 'rxjs';
 
 export class TranslateHttpLoader implements TranslateLoader {
-  constructor(private http: HttpClient, public prefix: string = "/assets/i18n/", public suffix: string = ".json") {}
+  constructor(private http: HttpClient, public prefix: string = "./assets/i18n/", public suffix: string = ".json") {}
 
   /**
    * Gets the translations from the server

--- a/projects/ngx-translate/http-loader/tests/http-loader.spec.ts
+++ b/projects/ngx-translate/http-loader/tests/http-loader.spec.ts
@@ -46,7 +46,7 @@ describe('TranslateLoader', () => {
     });
 
     // mock response after the xhr request, otherwise it will be undefined
-    http.expectOne('/assets/i18n/en.json').flush({
+    http.expectOne('./assets/i18n/en.json').flush({
       "TEST": "This is a test",
       "TEST2": "This is another test"
     });
@@ -69,11 +69,11 @@ describe('TranslateLoader', () => {
         expect(translate.instant('TEST')).toEqual('This is a test 2');
       });
 
-      http.expectOne('/assets/i18n/en.json').flush({"TEST": "This is a test 2"});
+      http.expectOne('./assets/i18n/en.json').flush({"TEST": "This is a test 2"});
     });
 
     // mock response after the xhr request, otherwise it will be undefined
-    http.expectOne('/assets/i18n/en.json').flush({"TEST": "This is a test"});
+    http.expectOne('./assets/i18n/en.json').flush({"TEST": "This is a test"});
   });
 
   it('should be able to reset a lang', (done: Function) => {
@@ -101,6 +101,6 @@ describe('TranslateLoader', () => {
     });
 
     // mock response after the xhr request, otherwise it will be undefined
-    http.expectOne('/assets/i18n/en.json').flush({"TEST": "This is a test"});
+    http.expectOne('./assets/i18n/en.json').flush({"TEST": "This is a test"});
   });
 });


### PR DESCRIPTION
Re-implements changes from #12, since they were backed out due to failing tests.

@ocombe Would you mind reviewing when you get a moment? Thanks!